### PR TITLE
Quick fix to work with Python 3.10

### DIFF
--- a/src/_chacha20.c
+++ b/src/_chacha20.c
@@ -6,7 +6,7 @@
 
 #include <string.h>
 #include <stdio.h>
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // #include "prtypes.h"
@@ -130,7 +130,7 @@ static PyObject * _chacha20_cipher(PyObject *self, PyObject *args) {
     ChaCha20XOR(out, (unsigned char *)in, msgLen, (unsigned char *)key, (unsigned char *)nonce,
         counter);
 
-    return Py_BuildValue("y#", out, msgLen);
+    return Py_BuildValue("y#", out, Py_SAFE_DOWNCAST(msgLen, Py_ssize_t, size_t));
 }
 
 static PyMethodDef _chacha20__methods__[] = {

--- a/src/_poly1305.c
+++ b/src/_poly1305.c
@@ -8,7 +8,7 @@
 
 #include <string.h>
 #include <stdint.h>
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "_poly1305.h"


### PR DESCRIPTION
As Python 3.10 made breaking changes to C bindings (see https://bugs.python.org/issue40943 and https://www.python.org/dev/peps/pep-0353/), here's a quick fix to get this module working with this Python version.

I'm not 100% sure if this is the right way to go, but as long as the payload is limited to 2GB, that should suffice.